### PR TITLE
Add support for other regex engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features fancy-regex

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,17 @@ build = "build.rs"
 edition = "2021"
 rust-version = "1.56"
 
+[features]
+default = ["onig"]
+
+onig = []
+regex = []
+fancy-regex = []
+
 [dependencies]
 onig = { version = "6.5", default-features = false }
+regex = { version = "1", default-features = false, features = ["std", "unicode", "perf", "perf-dfa-full"] }
+fancy-regex = { version = "0.14", default-features = false, features = ["std", "unicode", "perf"] }
 
 [build-dependencies]
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ rust-version = "1.56"
 default = ["onig"]
 
 onig = []
-regex = []
-fancy-regex = []
+regex = ["dep:regex"]
+fancy-regex = ["dep:fancy-regex"]
 
 [dependencies]
+# The default regex engine. Use default-feature = false to disable it.
 onig = { version = "6.5", default-features = false }
-regex = { version = "1", default-features = false, features = ["std", "unicode", "perf", "perf-dfa-full"] }
-fancy-regex = { version = "0.14", default-features = false, features = ["std", "unicode", "perf"] }
+# The Rust regex library. Does not support backtracking, so many patterns are unusable.
+regex = { version = "1", optional = true, default-features = false, features = ["std", "unicode", "perf", "perf-dfa-full"] }
+# A more complete Rust regex library supporting backtracking.
+fancy-regex = { version = "0.14", optional = true, default-features = false, features = ["std", "unicode", "perf"] }
 
 [build-dependencies]
 glob = "0.3"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,35 @@ be passed freely around. For performance reasons the `Match` returned is bound t
 them close together or clone/copy out the containing results as needed.
 
 ## Further Information
-This library depends on [onig](https://crates.io/crates/onig) for its regex execution, which itself is a Rust binding for the powerful [Oniguruma](https://github.com/kkos/oniguruma) regex library. If in doubt why a specific regex doesn't work, this is the best place to look for more information what patterns are supported and how to use advanced features.
+
+This library supports multiple regex engines through feature flags. By default,
+it uses [onig](https://crates.io/crates/onig), which is a Rust binding for the
+powerful [Oniguruma](https://github.com/kkos/oniguruma) regex library. You can
+also use the standard Rust regex engine or fancy-regex by enabling the
+respective features:
+
+The default engine, and at this time the most performant one, is `onig`:
+
+```toml
+[dependencies]
+grok = { version = "2.0", features = ["onig"] }
+```
+
+The `fancy-regex` engine is a more complete Rust regex library supporting
+backtracking:
+
+```toml
+[dependencies]
+grok = { version = "2.0", default-features = false, features = ["fancy-regex"] }
+```
+
+The `regex` engine is supported, but it does not support backtracking, so many
+patterns are unusable. This is not recommended for most use cases:
+
+```toml
+[dependencies]
+grok = { version = "2.0", default-features = false, features = ["regex"] }
+```
 
 ## License
 `grok` is distributed under the terms of the Apache License (Version 2.0). 

--- a/patterns/firewalls.pattern
+++ b/patterns/firewalls.pattern
@@ -83,9 +83,19 @@ CISCOFW713172 Group = %{GREEDYDATA:group}, IP = %{IP:src_ip}, Automatic NAT Dete
 CISCOFW733100 \[\s*%{DATA:drop_type}\s*\] drop %{DATA:drop_rate_id} exceeded. Current burst rate is %{INT:drop_rate_current_burst} per second, max configured rate is %{INT:drop_rate_max_burst}; Current average rate is %{INT:drop_rate_current_avg} per second, max configured rate is %{INT:drop_rate_max_avg}; Cumulative total count is %{INT:drop_total_count}
 #== End Cisco ASA ==
 
+IPTABLES_TCP_FLAGS (CWR |ECE |URG |ACK |PSH |RST |SYN |FIN )*
+IPTABLES_TCP_PART (?:SEQ=%{INT:[iptables][tcp][seq]:int}\s+)?(?:ACK=%{INT:[iptables][tcp][ack]:int}\s+)?WINDOW=%{INT:[iptables][tcp][window]:int}\s+RES=0x%{BASE16NUM:[iptables][tcp_reserved_bits]}\s+%{IPTABLES_TCP_FLAGS:[iptables][tcp][flags]}
+
+IPTABLES4_FRAG (?:(?<= )(?:CE|DF|MF))*
+IPTABLES4_PART SRC=%{IPV4:[source][ip]}\s+DST=%{IPV4:[destination][ip]}\s+LEN=(?:%{INT:[iptables][length]:int})?\s+TOS=(?:0|0x%{BASE16NUM:[iptables][tos]})?\s+PREC=(?:0x%{BASE16NUM:[iptables][precedence_bits]})?\s+TTL=(?:%{INT:[iptables][ttl]:int})?\s+ID=(?:%{INT:[iptables][id]})?\s+(?:%{IPTABLES4_FRAG:[iptables][fragment_flags]})?(?:\s+FRAG: %{INT:[iptables][fragment_offset]:int})?
+IPTABLES6_PART SRC=%{IPV6:[source][ip]}\s+DST=%{IPV6:[destination][ip]}\s+LEN=(?:%{INT:[iptables][length]:int})?\s+TC=(?:0|0x%{BASE16NUM:[iptables][tos]})?\s+HOPLIMIT=(?:%{INT:[iptables][ttl]:int})?\s+FLOWLBL=(?:%{INT:[iptables][flow_label]})?
+
+IPTABLES IN=(?:%{NOTSPACE:[observer][ingress][interface][name]})?\s+OUT=(?:%{NOTSPACE:[observer][egress][interface][name]})?\s+(?:MAC=(?:%{COMMONMAC:[destination][mac]})?(?::%{COMMONMAC:[source][mac]})?(?::[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2})?\s+)?(:?%{IPTABLES4_PART}|%{IPTABLES6_PART}).*?PROTO=(?:%{WORD:[network][transport]})?\s+SPT=(?:%{INT:[source][port]:int})?\s+DPT=(?:%{INT:[destination][port]:int})?\s+(?:%{IPTABLES_TCP_PART})?
+
 # Shorewall firewall logs
-SHOREWALL (%{SYSLOGTIMESTAMP:timestamp}) (%{WORD:nf_host}) kernel:.*Shorewall:(%{WORD:nf_action1})?:(%{WORD:nf_action2})?.*IN=(%{USERNAME:nf_in_interface})?.*(OUT= *MAC=(%{COMMONMAC:nf_dst_mac}):(%{COMMONMAC:nf_src_mac})?|OUT=%{USERNAME:nf_out_interface}).*SRC=(%{IPV4:nf_src_ip}).*DST=(%{IPV4:nf_dst_ip}).*LEN=(%{WORD:nf_len}).?*TOS=(%{WORD:nf_tos}).?*PREC=(%{WORD:nf_prec}).?*TTL=(%{INT:nf_ttl}).?*ID=(%{INT:nf_id}).?*PROTO=(%{WORD:nf_protocol}).?*SPT=(%{INT:nf_src_port}?.*DPT=%{INT:nf_dst_port}?.*)
+SHOREWALL (?:%{SYSLOGTIMESTAMP:timestamp}) (?:%{WORD:[observer][hostname]}) .*Shorewall:(?:%{WORD:[shorewall][firewall][type]})?:(?:%{WORD:[shorewall][firewall][action]})?.*%{IPTABLES}
 #== End Shorewall
 #== SuSE Firewall 2 ==
-SFW2 ((%{SYSLOGTIMESTAMP})|(%{TIMESTAMP_ISO8601}))\s*%{HOSTNAME}\s*kernel\S+\s*%{NAGIOSTIME}\s*SFW2\-INext\-%{NOTSPACE:nf_action}\s*IN=%{USERNAME:nf_in_interface}.*OUT=((\s*%{USERNAME:nf_out_interface})|(\s*))MAC=((%{COMMONMAC:nf_dst_mac}:%{COMMONMAC:nf_src_mac})|(\s*)).*SRC=%{IP:nf_src_ip}\s*DST=%{IP:nf_dst_ip}.*PROTO=%{WORD:nf_protocol}((.*SPT=%{INT:nf_src_port}.*DPT=%{INT:nf_dst_port}.*)|())
+SFW2_LOG_PREFIX SFW2\-INext\-%{NOTSPACE:[suse][firewall][action]}
+SFW2 ((?:%{SYSLOGTIMESTAMP:timestamp})|(?:%{TIMESTAMP_ISO8601:timestamp}))\s*%{HOSTNAME:[observer][hostname]}.*?%{SFW2_LOG_PREFIX:[suse][firewall][log_prefix]}\s*%{IPTABLES}
 #== End SuSE ==

--- a/src/fancy_regex.rs
+++ b/src/fancy_regex.rs
@@ -1,0 +1,134 @@
+use crate::Error;
+use fancy_regex::{Captures, Regex};
+use std::collections::{btree_map, BTreeMap, HashMap};
+
+/// The `Pattern` represents a compiled regex, ready to be matched against arbitrary text.
+#[derive(Debug)]
+pub struct FancyRegexPattern {
+    regex: Regex,
+    pub(crate) names: BTreeMap<String, usize>,
+}
+
+impl FancyRegexPattern {
+    /// Creates a new pattern from a raw regex string and an alias map to identify the
+    /// fields properly.
+    pub(crate) fn new(regex: &str, alias: &HashMap<String, String>) -> Result<Self, Error> {
+        match Regex::new(regex) {
+            Ok(r) => Ok({
+                let mut names = BTreeMap::new();
+                for (i, name) in r.capture_names().enumerate() {
+                    if let Some(name) = name {
+                        let name = match alias.iter().find(|&(_k, v)| *v == name) {
+                            Some(item) => item.0.clone(),
+                            None => String::from(name),
+                        };
+                        names.insert(name, i);
+                    }
+                }
+                Self { regex: r, names }
+            }),
+            Err(e) => {
+                eprintln!("Regex compilation failed: {e:?}");
+                Err(Error::RegexCompilationFailed(regex.into()))
+            }
+        }
+    }
+
+    /// Matches this compiled `Pattern` against the text and returns the matches.
+    pub fn match_against<'a>(&'a self, text: &'a str) -> Option<FancyRegexMatches<'a>> {
+        self.regex.captures(text).ok().flatten().and_then(|caps| {
+            Some(FancyRegexMatches {
+                text,
+                captures: caps,
+                pattern: self,
+            })
+        })
+    }
+
+    /// Returns all names this `Pattern` captures.
+    pub fn capture_names(&self) -> impl Iterator<Item = &str> {
+        self.names.keys().map(|s| s.as_str())
+    }
+}
+
+/// The `Matches` represent matched results from a `Pattern` against a provided text.
+#[derive(Debug)]
+pub struct FancyRegexMatches<'a> {
+    text: &'a str,
+    captures: Captures<'a>,
+    pattern: &'a FancyRegexPattern,
+}
+
+impl<'a> FancyRegexMatches<'a> {
+    /// Instantiates the matches for a pattern after the match.
+    pub(crate) fn new(
+        text: &'a str,
+        captures: Captures<'a>,
+        pattern: &'a FancyRegexPattern,
+    ) -> Self {
+        FancyRegexMatches {
+            text,
+            captures,
+            pattern,
+        }
+    }
+
+    /// Gets the value for the name (or) alias if found, `None` otherwise.
+    pub fn get(&self, name_or_alias: &str) -> Option<&str> {
+        self.pattern
+            .names
+            .get(name_or_alias)
+            .and_then(|&idx| self.captures.get(idx))
+            .map(|m| m.as_str())
+    }
+
+    /// Returns the number of matches.
+    pub fn len(&self) -> usize {
+        self.captures.len() - 1
+    }
+
+    /// Returns true if there are no matches, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a tuple of key/value with all the matches found.
+    ///
+    /// Note that if no match is found, the value is empty.
+    pub fn iter(&'a self) -> FancyRegexMatchesIter<'a> {
+        FancyRegexMatchesIter {
+            text: &self.text,
+            captures: &self.captures,
+            names: self.pattern.names.iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a FancyRegexMatches<'a> {
+    type Item = (&'a str, &'a str);
+    type IntoIter = FancyRegexMatchesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An `Iterator` over all matches, accessible via `Matches`.
+pub struct FancyRegexMatchesIter<'a> {
+    text: &'a str,
+    captures: &'a Captures<'a>,
+    names: btree_map::Iter<'a, String, usize>,
+}
+
+impl<'a> Iterator for FancyRegexMatchesIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, &v) in self.names.by_ref() {
+            if let Some(m) = self.captures.get(v) {
+                return Some((k.as_str(), m.as_str()));
+            }
+        }
+        None
+    }
+}

--- a/src/fancy_regex.rs
+++ b/src/fancy_regex.rs
@@ -6,7 +6,7 @@ use std::collections::{btree_map, BTreeMap, HashMap};
 #[derive(Debug)]
 pub struct FancyRegexPattern {
     regex: Regex,
-    pub(crate) names: BTreeMap<String, usize>,
+    names: BTreeMap<String, usize>,
 }
 
 impl FancyRegexPattern {
@@ -37,7 +37,6 @@ impl FancyRegexPattern {
     pub fn match_against<'a>(&'a self, text: &'a str) -> Option<FancyRegexMatches<'a>> {
         self.regex.captures(text).ok().flatten().and_then(|caps| {
             Some(FancyRegexMatches {
-                text,
                 captures: caps,
                 pattern: self,
             })
@@ -53,25 +52,11 @@ impl FancyRegexPattern {
 /// The `Matches` represent matched results from a `Pattern` against a provided text.
 #[derive(Debug)]
 pub struct FancyRegexMatches<'a> {
-    text: &'a str,
     captures: Captures<'a>,
     pattern: &'a FancyRegexPattern,
 }
 
 impl<'a> FancyRegexMatches<'a> {
-    /// Instantiates the matches for a pattern after the match.
-    pub(crate) fn new(
-        text: &'a str,
-        captures: Captures<'a>,
-        pattern: &'a FancyRegexPattern,
-    ) -> Self {
-        FancyRegexMatches {
-            text,
-            captures,
-            pattern,
-        }
-    }
-
     /// Gets the value for the name (or) alias if found, `None` otherwise.
     pub fn get(&self, name_or_alias: &str) -> Option<&str> {
         self.pattern
@@ -96,7 +81,6 @@ impl<'a> FancyRegexMatches<'a> {
     /// Note that if no match is found, the value is empty.
     pub fn iter(&'a self) -> FancyRegexMatchesIter<'a> {
         FancyRegexMatchesIter {
-            text: &self.text,
             captures: &self.captures,
             names: self.pattern.names.iter(),
         }
@@ -114,7 +98,6 @@ impl<'a> IntoIterator for &'a FancyRegexMatches<'a> {
 
 /// An `Iterator` over all matches, accessible via `Matches`.
 pub struct FancyRegexMatchesIter<'a> {
-    text: &'a str,
     captures: &'a Captures<'a>,
     names: btree_map::Iter<'a, String, usize>,
 }

--- a/src/fancy_regex.rs
+++ b/src/fancy_regex.rs
@@ -83,7 +83,7 @@ impl<'a> FancyRegexMatches<'a> {
 
     /// Returns the number of matches.
     pub fn len(&self) -> usize {
-        self.captures.len() - 1
+        self.pattern.names.len()
     }
 
     /// Returns true if there are no matches, false otherwise.

--- a/src/fancy_regex.rs
+++ b/src/fancy_regex.rs
@@ -27,10 +27,9 @@ impl FancyRegexPattern {
                 }
                 Self { regex: r, names }
             }),
-            Err(e) => {
-                eprintln!("Regex compilation failed: {e:?}");
-                Err(Error::RegexCompilationFailed(regex.into()))
-            }
+            Err(e) => Err(Error::RegexCompilationFailed(format!(
+                "Regex compilation failed: {e:?}:\n{regex}"
+            ))),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,10 +425,15 @@ mod tests {
         let pattern = grok
             .compile("%{DAY} %{MONTH} %{YEAR}", false)
             .expect("Error while compiling!");
+        assert_eq!(
+            pattern.capture_names().collect::<Vec<_>>(),
+            vec!["DAY", "MONTH", "YEAR"]
+        );
 
         let matches = pattern
             .match_against("Monday March 2012")
             .expect("No matches found!");
+        assert_eq!(matches.len(), 3);
         assert_eq!("Monday", matches.get("DAY").unwrap());
         assert_eq!("March", matches.get("MONTH").unwrap());
         assert_eq!("2012", matches.get("YEAR").unwrap());
@@ -476,6 +481,7 @@ mod tests {
         let matches = pattern
             .match_against("Monday March 2012")
             .expect("No matches found!");
+        assert_eq!(matches.len(), 4);
         let mut found = 0;
         for (k, v) in matches.iter() {
             match k {
@@ -507,6 +513,7 @@ mod tests {
         let matches = pattern
             .match_against("Monday March 2012")
             .expect("No matches found!");
+        assert_eq!(matches.len(), 4);
         let mut found = 0;
         for (k, v) in &matches {
             match k {
@@ -569,6 +576,7 @@ mod tests {
             .match_against("[thread1]")
             .expect("No matches found!");
         assert_eq!("thread1", matches.get("threadname").unwrap());
+        assert_eq!(matches.len(), 1);
     }
 
     #[test]
@@ -582,6 +590,7 @@ mod tests {
             .match_against("[thread1]")
             .expect("No matches found!");
         let mut found = 0;
+        assert_eq!(matches.len(), 1);
         for (k, v) in matches.iter() {
             assert_eq!("threadname", k);
             assert_eq!("thread1", v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,37 @@
 
 include!(concat!(env!("OUT_DIR"), "/default_patterns.rs"));
 
-use onig::{MatchParam, Regex, Region, SearchOptions};
-use std::collections::btree_map::Iter as MapIter;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error as StdError;
 use std::fmt;
+
+mod fancy_regex;
+mod onig;
+mod regex;
+
+// If fancy-regex is enabled, we use it. Otherwise if onig is enabled, use that.
+// Only use regex if it is enabled and no other feature is enabled.
+
+#[cfg(feature = "fancy-regex")]
+pub use fancy_regex::{
+    FancyRegexMatches as Matches, FancyRegexMatchesIter as MatchesIter,
+    FancyRegexPattern as Pattern,
+};
+
+#[cfg(all(feature = "onig", not(feature = "fancy-regex")))]
+pub use onig::{OnigMatches as Matches, OnigMatchesIter as MatchesIter, OnigPattern as Pattern};
+
+#[cfg(all(not(feature = "onig"), not(feature = "fancy-regex"), feature = "regex"))]
+pub use regex::{
+    RegexMatches as Matches, RegexMatchesIter as MatchesIter, RegexPattern as Pattern,
+};
+
+#[cfg(all(
+    not(feature = "onig"),
+    not(feature = "fancy-regex"),
+    not(feature = "regex")
+))]
+compile_error!("No regex engine selected. Please enable one of the following features: fancy-regex, onig, regex");
 
 const MAX_RECURSION: usize = 1024;
 
@@ -25,164 +51,6 @@ const DEFINITION_INDEX: usize = 4;
 /// Returns the default patterns, also used by the default constructor of `Grok`.
 pub fn patterns<'a>() -> &'a [(&'a str, &'a str)] {
     PATTERNS
-}
-
-#[derive(Debug)]
-pub struct Captures<'a> {
-    text: &'a str,
-    region: Region,
-    offset: usize,
-}
-
-impl<'a> Captures<'a> {
-    pub fn at(&self, pos: usize) -> Option<&'a str> {
-        self.region
-            .pos(pos)
-            .map(|(start, end)| &self.text[start..end])
-    }
-
-    pub fn len(&self) -> usize {
-        self.region.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Offset of the captures within the given string slice.
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-}
-
-/// The `Matches` represent matched results from a `Pattern` against a provided text.
-#[derive(Debug)]
-pub struct Matches<'a> {
-    captures: Captures<'a>,
-    names: &'a BTreeMap<String, u32>,
-}
-
-impl<'a> Matches<'a> {
-    /// Instantiates the matches for a pattern after the match.
-    fn new(captures: Captures<'a>, names: &'a BTreeMap<String, u32>) -> Self {
-        Matches { captures, names }
-    }
-
-    /// Gets the value for the name (or) alias if found, `None` otherwise.
-    pub fn get(&self, name_or_alias: &str) -> Option<&str> {
-        match self.names.get(name_or_alias) {
-            Some(found) => self.captures.at(*found as usize),
-            None => None,
-        }
-    }
-
-    /// Returns the number of matches.
-    pub fn len(&self) -> usize {
-        self.captures.len() - 1
-    }
-
-    /// Returns true if there are no matches, false otherwise.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns a tuple of key/value with all the matches found.
-    ///
-    /// Note that if no match is found, the value is empty.
-    pub fn iter(&'a self) -> MatchesIter<'a> {
-        MatchesIter {
-            captures: &self.captures,
-            names: self.names.iter(),
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a Matches<'a> {
-    type Item = (&'a str, &'a str);
-    type IntoIter = MatchesIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-/// An `Iterator` over all matches, accessible via `Matches`.
-pub struct MatchesIter<'a> {
-    captures: &'a Captures<'a>,
-    names: MapIter<'a, String, u32>,
-}
-
-impl<'a> Iterator for MatchesIter<'a> {
-    type Item = (&'a str, &'a str);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        //while let Some((k, v)) = self.names.next() {
-        for (k, v) in self.names.by_ref() {
-            match self.captures.at(*v as usize) {
-                Some(value) => return Some((k.as_str(), value)),
-                None => {
-                    continue;
-                }
-            }
-        }
-        None
-    }
-}
-
-/// The `Pattern` represents a compiled regex, ready to be matched against arbitrary text.
-#[derive(Debug)]
-pub struct Pattern {
-    regex: Regex,
-    names: BTreeMap<String, u32>,
-}
-
-impl Pattern {
-    /// Creates a new pattern from a raw regex string and an alias map to identify the
-    /// fields properly.
-    fn new(regex: &str, alias: &HashMap<String, String>) -> Result<Self, Error> {
-        match Regex::new(regex) {
-            Ok(r) => Ok({
-                let mut names = BTreeMap::new();
-                r.foreach_name(|cap_name, cap_idx| {
-                    let name = match alias.iter().find(|&(_k, v)| *v == cap_name) {
-                        Some(item) => item.0.clone(),
-                        None => String::from(cap_name),
-                    };
-                    names.insert(name, cap_idx[0]);
-                    true
-                });
-                Pattern { regex: r, names }
-            }),
-            Err(_) => Err(Error::RegexCompilationFailed(regex.into())),
-        }
-    }
-
-    /// Matches this compiled `Pattern` against the text and returns the matches.
-    pub fn match_against<'a>(&'a self, text: &'a str) -> Option<Matches<'a>> {
-        // Inlined version of the onig methods that cause an internal panic
-        let this = &self.regex;
-        let mut region = Region::new();
-        let to = text.len();
-        let options = SearchOptions::SEARCH_OPTION_NONE;
-        let match_param = MatchParam::default();
-        let result = this.search_with_param(text, 0, to, options, Some(&mut region), match_param);
-
-        match result {
-            Ok(r) => r,
-            Err(_) => None,
-        }
-        .map(|pos| Captures {
-            text: text,
-            region,
-            offset: pos,
-        })
-        .map(|cap| Matches::new(cap, &self.names))
-    }
-
-    /// Returns all names this `Pattern` captures.
-    pub fn capture_names(&self) -> impl Iterator<Item = &str> {
-        self.names.keys().map(|s| s.as_str())
-    }
 }
 
 /// The `Grok` struct is the main entry point into using this library.
@@ -222,7 +90,7 @@ impl Grok {
         let mut iteration_left = MAX_RECURSION;
         let mut continue_iteration = true;
 
-        let grok_regex = match Regex::new(GROK_PATTERN) {
+        let grok_regex = match ::onig::Regex::new(GROK_PATTERN) {
             Ok(r) => r,
             Err(_) => return Err(Error::RegexCompilationFailed(GROK_PATTERN.into())),
         };

--- a/src/onig.rs
+++ b/src/onig.rs
@@ -46,7 +46,11 @@ impl OnigPattern {
             Ok(r) => r,
             Err(_) => None,
         }
-        .map(|_| OnigMatches::new(text, region, self))
+        .map(|_| OnigMatches {
+            text,
+            region,
+            pattern: self,
+        })
     }
 
     /// Returns all names this `Pattern` captures.
@@ -64,19 +68,6 @@ pub struct OnigMatches<'a> {
 }
 
 impl<'a> OnigMatches<'a> {
-    /// Instantiates the matches for a pattern after the match.
-    pub(crate) fn new(
-        text: &'a str,
-        region: Region,
-        pattern: &'a crate::onig::OnigPattern,
-    ) -> Self {
-        OnigMatches {
-            text,
-            region,
-            pattern,
-        }
-    }
-
     /// Gets the value for the name (or) alias if found, `None` otherwise.
     pub fn get(&self, name_or_alias: &str) -> Option<&str> {
         match self.pattern.names.get(name_or_alias) {

--- a/src/onig.rs
+++ b/src/onig.rs
@@ -1,0 +1,159 @@
+use crate::Error;
+use onig::{MatchParam, Regex, Region, SearchOptions};
+use std::collections::{btree_map, BTreeMap, HashMap};
+
+/// The `Pattern` represents a compiled regex, ready to be matched against arbitrary text.
+#[derive(Debug)]
+pub struct OnigPattern {
+    regex: Regex,
+    pub(crate) names: BTreeMap<String, u32>,
+}
+
+impl OnigPattern {
+    /// Creates a new pattern from a raw regex string and an alias map to identify the
+    /// fields properly.
+    pub(crate) fn new(regex: &str, alias: &HashMap<String, String>) -> Result<Self, Error> {
+        match Regex::new(regex) {
+            Ok(r) => Ok({
+                let mut names = BTreeMap::new();
+                r.foreach_name(|cap_name, cap_idx| {
+                    let name = match alias.iter().find(|&(_k, v)| *v == cap_name) {
+                        Some(item) => item.0.clone(),
+                        None => String::from(cap_name),
+                    };
+                    names.insert(name, cap_idx[0]);
+                    true
+                });
+                Self { regex: r, names }
+            }),
+            Err(e) => {
+                eprintln!("Regex compilation failed: {e:?}");
+                Err(Error::RegexCompilationFailed(regex.into()))
+            }
+        }
+    }
+
+    /// Matches this compiled `Pattern` against the text and returns the matches.
+    pub fn match_against<'a>(&'a self, text: &'a str) -> Option<OnigMatches<'a>> {
+        // Inlined version of the onig methods that cause an internal panic
+        let this = &self.regex;
+        let mut region = Region::new();
+        let to = text.len();
+        let options = SearchOptions::SEARCH_OPTION_NONE;
+        let match_param = MatchParam::default();
+        let result = this.search_with_param(text, 0, to, options, Some(&mut region), match_param);
+
+        match result {
+            Ok(r) => r,
+            Err(_) => None,
+        }
+        .map(|_| OnigMatches::new(text, OnigRegion { region }, self))
+    }
+
+    /// Returns all names this `Pattern` captures.
+    pub fn capture_names(&self) -> impl Iterator<Item = &str> {
+        self.names.keys().map(|s| s.as_str())
+    }
+}
+
+#[derive(Debug)]
+pub struct OnigRegion {
+    pub(crate) region: Region,
+}
+
+impl OnigRegion {
+    pub fn pos(&self, pos: usize) -> Option<(usize, usize)> {
+        self.region.pos(pos)
+    }
+
+    pub fn len(&self) -> usize {
+        self.region.len()
+    }
+}
+
+/// The `Matches` represent matched results from a `Pattern` against a provided text.
+#[derive(Debug)]
+pub struct OnigMatches<'a> {
+    text: &'a str,
+    region: crate::onig::OnigRegion,
+    pattern: &'a crate::onig::OnigPattern,
+}
+
+impl<'a> OnigMatches<'a> {
+    /// Instantiates the matches for a pattern after the match.
+    pub(crate) fn new(
+        text: &'a str,
+        region: crate::onig::OnigRegion,
+        pattern: &'a crate::onig::OnigPattern,
+    ) -> Self {
+        OnigMatches {
+            text,
+            region,
+            pattern,
+        }
+    }
+
+    /// Gets the value for the name (or) alias if found, `None` otherwise.
+    pub fn get(&self, name_or_alias: &str) -> Option<&str> {
+        match self.pattern.names.get(name_or_alias) {
+            Some(found) => self
+                .region
+                .pos(*found as usize)
+                .and_then(|(start, end)| Some(&self.text[start..end])),
+            None => None,
+        }
+    }
+
+    /// Returns the number of matches.
+    pub fn len(&self) -> usize {
+        self.region.len() - 1
+    }
+
+    /// Returns true if there are no matches, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a tuple of key/value with all the matches found.
+    ///
+    /// Note that if no match is found, the value is empty.
+    pub fn iter(&'a self) -> OnigMatchesIter<'a> {
+        OnigMatchesIter {
+            text: &self.text,
+            region: &self.region,
+            names: self.pattern.names.iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a OnigMatches<'a> {
+    type Item = (&'a str, &'a str);
+    type IntoIter = OnigMatchesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An `Iterator` over all matches, accessible via `Matches`.
+pub struct OnigMatchesIter<'a> {
+    text: &'a str,
+    region: &'a crate::onig::OnigRegion,
+    names: btree_map::Iter<'a, String, u32>,
+}
+
+impl<'a> Iterator for OnigMatchesIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, v) in self.names.by_ref() {
+            match self.region.pos(*v as usize) {
+                Some((start, end)) => return Some((k.as_str(), &self.text[start..end])),
+                None => {
+                    continue;
+                }
+            }
+        }
+        None
+    }
+}

--- a/src/onig.rs
+++ b/src/onig.rs
@@ -46,7 +46,7 @@ impl OnigPattern {
             Ok(r) => r,
             Err(_) => None,
         }
-        .map(|_| OnigMatches::new(text, OnigRegion { region }, self))
+        .map(|_| OnigMatches::new(text, region, self))
     }
 
     /// Returns all names this `Pattern` captures.
@@ -55,26 +55,11 @@ impl OnigPattern {
     }
 }
 
-#[derive(Debug)]
-pub struct OnigRegion {
-    pub(crate) region: Region,
-}
-
-impl OnigRegion {
-    pub fn pos(&self, pos: usize) -> Option<(usize, usize)> {
-        self.region.pos(pos)
-    }
-
-    pub fn len(&self) -> usize {
-        self.region.len()
-    }
-}
-
 /// The `Matches` represent matched results from a `Pattern` against a provided text.
 #[derive(Debug)]
 pub struct OnigMatches<'a> {
     text: &'a str,
-    region: crate::onig::OnigRegion,
+    region: Region,
     pattern: &'a crate::onig::OnigPattern,
 }
 
@@ -82,7 +67,7 @@ impl<'a> OnigMatches<'a> {
     /// Instantiates the matches for a pattern after the match.
     pub(crate) fn new(
         text: &'a str,
-        region: crate::onig::OnigRegion,
+        region: Region,
         pattern: &'a crate::onig::OnigPattern,
     ) -> Self {
         OnigMatches {
@@ -105,7 +90,8 @@ impl<'a> OnigMatches<'a> {
 
     /// Returns the number of matches.
     pub fn len(&self) -> usize {
-        self.region.len() - 1
+        debug_assert_eq!(self.region.len() - 1, self.pattern.names.len());
+        self.pattern.names.len()
     }
 
     /// Returns true if there are no matches, false otherwise.
@@ -137,7 +123,7 @@ impl<'a> IntoIterator for &'a OnigMatches<'a> {
 /// An `Iterator` over all matches, accessible via `Matches`.
 pub struct OnigMatchesIter<'a> {
     text: &'a str,
-    region: &'a crate::onig::OnigRegion,
+    region: &'a Region,
     names: btree_map::Iter<'a, String, u32>,
 }
 

--- a/src/onig.rs
+++ b/src/onig.rs
@@ -26,10 +26,9 @@ impl OnigPattern {
                 });
                 Self { regex: r, names }
             }),
-            Err(e) => {
-                eprintln!("Regex compilation failed: {e:?}");
-                Err(Error::RegexCompilationFailed(regex.into()))
-            }
+            Err(e) => Err(Error::RegexCompilationFailed(format!(
+                "Regex compilation failed: {e:?}:\n{regex}"
+            ))),
         }
     }
 

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -36,7 +36,6 @@ impl RegexPattern {
     /// Matches this compiled `Pattern` against the text and returns the matches.
     pub fn match_against<'a>(&'a self, text: &'a str) -> Option<RegexMatches<'a>> {
         self.regex.captures(text).map(|caps| RegexMatches {
-            text,
             captures: caps,
             pattern: self,
         })
@@ -51,21 +50,11 @@ impl RegexPattern {
 /// The `Matches` represent matched results from a `Pattern` against a provided text.
 #[derive(Debug)]
 pub struct RegexMatches<'a> {
-    text: &'a str,
     captures: Captures<'a>,
     pattern: &'a RegexPattern,
 }
 
 impl<'a> RegexMatches<'a> {
-    /// Instantiates the matches for a pattern after the match.
-    pub(crate) fn new(text: &'a str, captures: Captures<'a>, pattern: &'a RegexPattern) -> Self {
-        RegexMatches {
-            text,
-            captures,
-            pattern,
-        }
-    }
-
     /// Gets the value for the name (or) alias if found, `None` otherwise.
     pub fn get(&self, name_or_alias: &str) -> Option<&str> {
         self.pattern
@@ -90,7 +79,6 @@ impl<'a> RegexMatches<'a> {
     /// Note that if no match is found, the value is empty.
     pub fn iter(&'a self) -> RegexMatchesIter<'a> {
         RegexMatchesIter {
-            text: &self.text,
             captures: &self.captures,
             names: self.pattern.names.iter(),
         }
@@ -108,7 +96,6 @@ impl<'a> IntoIterator for &'a RegexMatches<'a> {
 
 /// An `Iterator` over all matches, accessible via `Matches`.
 pub struct RegexMatchesIter<'a> {
-    text: &'a str,
     captures: &'a Captures<'a>,
     names: btree_map::Iter<'a, String, usize>,
 }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,0 +1,125 @@
+use crate::Error;
+use regex::{Captures, Regex};
+use std::collections::{btree_map, BTreeMap, HashMap};
+
+/// The `Pattern` represents a compiled regex, ready to be matched against arbitrary text.
+#[derive(Debug)]
+pub struct RegexPattern {
+    regex: Regex,
+    pub(crate) names: BTreeMap<String, usize>,
+}
+
+impl RegexPattern {
+    /// Creates a new pattern from a raw regex string and an alias map to identify the
+    /// fields properly.
+    pub(crate) fn new(regex: &str, alias: &HashMap<String, String>) -> Result<Self, Error> {
+        match Regex::new(regex) {
+            Ok(r) => Ok({
+                let mut names = BTreeMap::new();
+                for (i, name) in r.capture_names().enumerate() {
+                    if let Some(name) = name {
+                        let name = match alias.iter().find(|&(_k, v)| *v == name) {
+                            Some(item) => item.0.clone(),
+                            None => String::from(name),
+                        };
+                        names.insert(name, i);
+                    }
+                }
+                Self { regex: r, names }
+            }),
+            Err(_) => Err(Error::RegexCompilationFailed(regex.into())),
+        }
+    }
+
+    /// Matches this compiled `Pattern` against the text and returns the matches.
+    pub fn match_against<'a>(&'a self, text: &'a str) -> Option<RegexMatches<'a>> {
+        self.regex.captures(text).map(|caps| RegexMatches {
+            text,
+            captures: caps,
+            pattern: self,
+        })
+    }
+
+    /// Returns all names this `Pattern` captures.
+    pub fn capture_names(&self) -> impl Iterator<Item = &str> {
+        self.names.keys().map(|s| s.as_str())
+    }
+}
+
+/// The `Matches` represent matched results from a `Pattern` against a provided text.
+#[derive(Debug)]
+pub struct RegexMatches<'a> {
+    text: &'a str,
+    captures: Captures<'a>,
+    pattern: &'a RegexPattern,
+}
+
+impl<'a> RegexMatches<'a> {
+    /// Instantiates the matches for a pattern after the match.
+    pub(crate) fn new(text: &'a str, captures: Captures<'a>, pattern: &'a RegexPattern) -> Self {
+        RegexMatches {
+            text,
+            captures,
+            pattern,
+        }
+    }
+
+    /// Gets the value for the name (or) alias if found, `None` otherwise.
+    pub fn get(&self, name_or_alias: &str) -> Option<&str> {
+        self.pattern
+            .names
+            .get(name_or_alias)
+            .and_then(|&idx| self.captures.get(idx))
+            .map(|m| m.as_str())
+    }
+
+    /// Returns the number of matches.
+    pub fn len(&self) -> usize {
+        self.captures.len() - 1
+    }
+
+    /// Returns true if there are no matches, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a tuple of key/value with all the matches found.
+    ///
+    /// Note that if no match is found, the value is empty.
+    pub fn iter(&'a self) -> RegexMatchesIter<'a> {
+        RegexMatchesIter {
+            text: &self.text,
+            captures: &self.captures,
+            names: self.pattern.names.iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a RegexMatches<'a> {
+    type Item = (&'a str, &'a str);
+    type IntoIter = RegexMatchesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An `Iterator` over all matches, accessible via `Matches`.
+pub struct RegexMatchesIter<'a> {
+    text: &'a str,
+    captures: &'a Captures<'a>,
+    names: btree_map::Iter<'a, String, usize>,
+}
+
+impl<'a> Iterator for RegexMatchesIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, &v) in self.names.by_ref() {
+            if let Some(m) = self.captures.get(v) {
+                return Some((k.as_str(), m.as_str()));
+            }
+        }
+        None
+    }
+}

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -27,7 +27,9 @@ impl RegexPattern {
                 }
                 Self { regex: r, names }
             }),
-            Err(_) => Err(Error::RegexCompilationFailed(regex.into())),
+            Err(e) => Err(Error::RegexCompilationFailed(format!(
+                "Regex compilation failed: {e:?}:\n{regex}"
+            ))),
         }
     }
 

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -77,7 +77,7 @@ impl<'a> RegexMatches<'a> {
 
     /// Returns the number of matches.
     pub fn len(&self) -> usize {
-        self.captures.len() - 1
+        self.pattern.names.len()
     }
 
     /// Returns true if there are no matches, false otherwise.


### PR DESCRIPTION
This add support for other regex engines (`regex` and `fancy-regex`), which helps users where the compilation requirements of `onig` may be onerous. 

Note that `fancy-regex` is quite complete, but performs 4x to 8x slower than `onig` in nearly all cases. This feature is only recommended for specific cases.

`onig`:

```
     Running benches/apache.rs (target/release/deps/apache-b74c62eeadec2425)

running 8 tests
test bench_apache_log_match                  ... bench:       1,144.00 ns/iter (+/- 15.69)
test bench_apache_log_match_anchor           ... bench:       1,151.41 ns/iter (+/- 30.85)
test bench_apache_log_no_match_end           ... bench:      22,606.82 ns/iter (+/- 458.42)
test bench_apache_log_no_match_end_anchor    ... bench:       4,361.95 ns/iter (+/- 53.70)
test bench_apache_log_no_match_middle        ... bench:       1,158.63 ns/iter (+/- 69.56)
test bench_apache_log_no_match_middle_anchor ... bench:       1,156.04 ns/iter (+/- 23.31)
test bench_apache_log_no_match_start         ... bench:      13,076.02 ns/iter (+/- 484.84)
test bench_apache_log_no_match_start_anchor  ... bench:       1,998.12 ns/iter (+/- 34.15)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out; finished in 6.13s

     Running benches/log.rs (target/release/deps/log-c28f491c1fb11aff)

running 4 tests
test bench_log_match                 ... bench:         466.83 ns/iter (+/- 53.36)
test bench_log_match_with_anchors    ... bench:         465.55 ns/iter (+/- 58.31)
test bench_log_no_match              ... bench:         764.98 ns/iter (+/- 43.80)
test bench_log_no_match_with_anchors ... bench:         497.61 ns/iter (+/- 29.82)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 14.87s

     Running benches/simple.rs (target/release/deps/simple-70842287ce6bfb68)

running 4 tests
test bench_simple_pattern_match                ... bench:         187.89 ns/iter (+/- 40.46)
test bench_simple_pattern_match_with_anchor    ... bench:         203.80 ns/iter (+/- 50.47)
test bench_simple_pattern_no_match             ... bench:         107.15 ns/iter (+/- 5.59)
test bench_simple_pattern_no_match_with_anchor ... bench:         103.68 ns/iter (+/- 1.65)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 4.99s
```

`fancy-regex`:

```
     Running benches/apache.rs (target/release/deps/apache-bcbee4386bed9361)

running 8 tests
test bench_apache_log_match                  ... bench:       4,363.05 ns/iter (+/- 301.51)
test bench_apache_log_match_anchor           ... bench:       4,569.64 ns/iter (+/- 76.25)
test bench_apache_log_no_match_end           ... bench:     116,130.02 ns/iter (+/- 929.82)
test bench_apache_log_no_match_end_anchor    ... bench:      13,160.91 ns/iter (+/- 438.69)
test bench_apache_log_no_match_middle        ... bench:       4,391.48 ns/iter (+/- 162.50)
test bench_apache_log_no_match_middle_anchor ... bench:       4,442.55 ns/iter (+/- 241.33)
test bench_apache_log_no_match_start         ... bench:      64,305.78 ns/iter (+/- 1,142.82)
test bench_apache_log_no_match_start_anchor  ... bench:       3,121.63 ns/iter (+/- 146.07)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out; finished in 7.15s

     Running benches/log.rs (target/release/deps/log-de9fb364d00d680a)

running 4 tests
test bench_log_match                 ... bench:       1,517.55 ns/iter (+/- 77.27)
test bench_log_match_with_anchors    ... bench:       1,606.26 ns/iter (+/- 166.34)
test bench_log_no_match              ... bench:       6,129.08 ns/iter (+/- 259.32)
test bench_log_no_match_with_anchors ... bench:       2,239.30 ns/iter (+/- 6,499.91)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 3.45s

     Running benches/simple.rs (target/release/deps/simple-edf4561d6b80b5aa)

running 4 tests
test bench_simple_pattern_match                ... bench:          82.42 ns/iter (+/- 2.01)
test bench_simple_pattern_match_with_anchor    ... bench:          54.09 ns/iter (+/- 4.42)
test bench_simple_pattern_no_match             ... bench:          35.46 ns/iter (+/- 3.08)
test bench_simple_pattern_no_match_with_anchor ... bench:          39.73 ns/iter (+/- 1.82)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 1.89s
```