### PR TITLE
Add support for PCRE2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,7 @@ jobs:
         with:
           command: test
           args: --no-default-features --features fancy-regex
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features pcre2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grok"
-version = "2.0.2"
+version = "2.1.0"
 authors = ["Matt Mastracci <matthew@mastracci.com>", "Michael Nitschinger <michael@nitschinger.at>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,20 @@ default = ["onig"]
 onig = []
 regex = ["dep:regex"]
 fancy-regex = ["dep:fancy-regex"]
+pcre2 = ["dep:pcre2"]
 
 [dependencies]
 # The default regex engine. Use default-feature = false to disable it.
 onig = { version = "6.5", default-features = false }
+
 # The Rust regex library. Does not support backtracking, so many patterns are unusable.
 regex = { version = "1", optional = true, default-features = false, features = ["std", "unicode", "perf", "perf-dfa-full"] }
+
 # A more complete Rust regex library supporting backtracking.
 fancy-regex = { version = "0.14", optional = true, default-features = false, features = ["std", "unicode", "perf"] }
+
+# A PCRE2 binding.
+pcre2 = { version = "0.2.9", optional = true }
 
 [build-dependencies]
 glob = "0.3"

--- a/README.md
+++ b/README.md
@@ -55,11 +55,19 @@ powerful [Oniguruma](https://github.com/kkos/oniguruma) regex library. You can
 also use the standard Rust regex engine or fancy-regex by enabling the
 respective features:
 
-The default engine, and at this time the most performant one, is `onig`:
+The default engine is `onig` for compatibility with previous 2.x releases:
 
 ```toml
 [dependencies]
 grok = { version = "2.0", features = ["onig"] }
+```
+
+The `pcre2` engine is a more complete Rust regex library supporting
+backtracking, JIT compilation and is the fastest engine for most use cases:
+
+```toml
+[dependencies]
+grok = { version = "2.0", default-features = false, features = ["pcre2"] }
 ```
 
 The `fancy-regex` engine is a more complete Rust regex library supporting

--- a/patterns/bacula.pattern
+++ b/patterns/bacula.pattern
@@ -39,8 +39,8 @@ BACULA_LOG_VSS (Generate )?VSS (Writer)?
 BACULA_LOG_MAXSTART Fatal error: Job canceled because max start delay time exceeded.
 BACULA_LOG_DUPLICATE Fatal error: JobId %{INT:duplicate} already running. Duplicate job not allowed.
 BACULA_LOG_NOJOBSTAT Fatal error: No Job status returned from FD.
-BACULA_LOG_FATAL_CONN Fatal error: bsock.c:133 Unable to connect to (Client: %{BACULA_HOST:client}|Storage daemon) on %{HOSTNAME}:%{POSINT}. ERR=(?<berror>%{GREEDYDATA})
-BACULA_LOG_NO_CONNECT Warning: bsock.c:127 Could not connect to (Client: %{BACULA_HOST:client}|Storage daemon) on %{HOSTNAME}:%{POSINT}. ERR=(?<berror>%{GREEDYDATA})
+BACULA_LOG_FATAL_CONN Fatal error: bsock.c:133 Unable to connect to (Client: %{BACULA_HOST:client}|Storage daemon) on %{HOSTNAME}:%{POSINT}. ERR=(%{GREEDYDATA})
+BACULA_LOG_NO_CONNECT Warning: bsock.c:127 Could not connect to (Client: %{BACULA_HOST:client}|Storage daemon) on %{HOSTNAME}:%{POSINT}. ERR=(%{GREEDYDATA})
 BACULA_LOG_NO_AUTH Fatal error: Unable to authenticate with File daemon at %{HOSTNAME}. Possible causes:
 BACULA_LOG_NOSUIT No prior or suitable Full backup found in catalog. Doing FULL backup.
 BACULA_LOG_NOPRIOR No prior Full backup Job record found.

--- a/src/pcre2.rs
+++ b/src/pcre2.rs
@@ -1,0 +1,121 @@
+use crate::Error;
+use pcre2::bytes::{Captures, Regex, RegexBuilder};
+use std::collections::{btree_map, BTreeMap, HashMap};
+
+/// The `Pattern` represents a compiled regex, ready to be matched against arbitrary text.
+#[derive(Debug)]
+pub struct Pcre2Pattern {
+    regex: Regex,
+    names: BTreeMap<String, usize>,
+}
+
+impl Pcre2Pattern {
+    /// Creates a new pattern from a raw regex string and an alias map to identify the
+    /// fields properly.
+    pub(crate) fn new(regex: &str, alias: &HashMap<String, String>) -> Result<Self, Error> {
+        let mut builder = RegexBuilder::new();
+        builder.jit_if_available(true);
+        builder.utf(true);
+        match builder.build(regex) {
+            Ok(r) => Ok({
+                let mut names = BTreeMap::new();
+                for (i, name) in r.capture_names().iter().enumerate() {
+                    if let Some(name) = name {
+                        let name = match alias.iter().find(|&(_k, v)| v == name) {
+                            Some(item) => item.0.clone(),
+                            None => String::from(name),
+                        };
+                        names.insert(name, i);
+                    }
+                }
+                Self { regex: r, names }
+            }),
+            Err(e) => Err(Error::RegexCompilationFailed(format!(
+                "Regex compilation failed: {e:?}:\n{regex}"
+            ))),
+        }
+    }
+
+    /// Matches this compiled `Pattern` against the text and returns the matches.
+    pub fn match_against<'a>(&'a self, text: &'a str) -> Option<Pcre2Matches<'a>> {
+        self.regex
+            .captures(text.as_bytes())
+            .ok()
+            .flatten()
+            .map(|caps| Pcre2Matches {
+                captures: caps,
+                pattern: self,
+            })
+    }
+
+    /// Returns all names this `Pattern` captures.
+    pub fn capture_names(&self) -> impl Iterator<Item = &str> {
+        self.names.keys().map(|s| s.as_str())
+    }
+}
+
+/// The `Matches` represent matched results from a `Pattern` against a provided text.
+#[derive(Debug)]
+pub struct Pcre2Matches<'a> {
+    captures: Captures<'a>,
+    pattern: &'a Pcre2Pattern,
+}
+
+impl<'a> Pcre2Matches<'a> {
+    /// Gets the value for the name (or) alias if found, `None` otherwise.
+    pub fn get(&self, name_or_alias: &str) -> Option<&str> {
+        self.pattern
+            .names
+            .get(name_or_alias)
+            .and_then(|&idx| self.captures.get(idx))
+            .map(|m| std::str::from_utf8(m.as_bytes()).unwrap())
+    }
+
+    /// Returns the number of matches.
+    pub fn len(&self) -> usize {
+        self.pattern.names.len()
+    }
+
+    /// Returns true if there are no matches, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a tuple of key/value with all the matches found.
+    ///
+    /// Note that if no match is found, the value is empty.
+    pub fn iter(&'a self) -> Pcre2MatchesIter<'a> {
+        Pcre2MatchesIter {
+            captures: &self.captures,
+            names: self.pattern.names.iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Pcre2Matches<'a> {
+    type Item = (&'a str, &'a str);
+    type IntoIter = Pcre2MatchesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An `Iterator` over all matches, accessible via `Matches`.
+pub struct Pcre2MatchesIter<'a> {
+    captures: &'a Captures<'a>,
+    names: btree_map::Iter<'a, String, usize>,
+}
+
+impl<'a> Iterator for Pcre2MatchesIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, &v) in self.names.by_ref() {
+            if let Some(m) = self.captures.get(v) {
+                return Some((k.as_str(), std::str::from_utf8(m.as_bytes()).unwrap()));
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
Enable the PCRE2 crate which seems to be significantly faster than onig (3x-8x faster):

With `pcre2`:

```
     Running benches/apache.rs (target/release/deps/apache-f30e9c1766c85071)

running 8 tests
test bench_apache_log_match                  ... bench:         450.01 ns/iter (+/- 32.01)
test bench_apache_log_match_anchor           ... bench:         453.31 ns/iter (+/- 29.71)
test bench_apache_log_no_match_end           ... bench:       3,472.72 ns/iter (+/- 457.27)
test bench_apache_log_no_match_end_anchor    ... bench:         665.03 ns/iter (+/- 81.74)
test bench_apache_log_no_match_middle        ... bench:         461.27 ns/iter (+/- 20.25)
test bench_apache_log_no_match_middle_anchor ... bench:         449.36 ns/iter (+/- 22.09)
test bench_apache_log_no_match_start         ... bench:       1,884.20 ns/iter (+/- 121.71)
test bench_apache_log_no_match_start_anchor  ... bench:         249.02 ns/iter (+/- 8.20)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out; finished in 13.38s

     Running benches/log.rs (target/release/deps/log-1fc987d2bf71525c)

running 4 tests
test bench_log_match                 ... bench:         168.32 ns/iter (+/- 8.42)
test bench_log_match_with_anchors    ... bench:         166.24 ns/iter (+/- 9.23)
test bench_log_no_match              ... bench:         261.31 ns/iter (+/- 20.63)
test bench_log_no_match_with_anchors ... bench:         138.88 ns/iter (+/- 14.65)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 12.31s

     Running benches/simple.rs (target/release/deps/simple-ef7a70d8b21688bc)

running 4 tests
test bench_simple_pattern_match                ... bench:          78.32 ns/iter (+/- 11.66)
test bench_simple_pattern_match_with_anchor    ... bench:          81.64 ns/iter (+/- 3.53)
test bench_simple_pattern_no_match             ... bench:          78.53 ns/iter (+/- 10.32)
test bench_simple_pattern_no_match_with_anchor ... bench:          73.62 ns/iter (+/- 11.34)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 4.36s
```

With `onig`:

```
     Running benches/apache.rs (target/release/deps/apache-b74c62eeadec2425)

running 8 tests
test bench_apache_log_match                  ... bench:       1,159.12 ns/iter (+/- 72.14)
test bench_apache_log_match_anchor           ... bench:       1,144.51 ns/iter (+/- 34.72)
test bench_apache_log_no_match_end           ... bench:      22,726.43 ns/iter (+/- 1,024.36)
test bench_apache_log_no_match_end_anchor    ... bench:       4,372.33 ns/iter (+/- 171.75)
test bench_apache_log_no_match_middle        ... bench:       1,151.09 ns/iter (+/- 38.32)
test bench_apache_log_no_match_middle_anchor ... bench:       1,150.05 ns/iter (+/- 47.56)
test bench_apache_log_no_match_start         ... bench:      13,002.12 ns/iter (+/- 491.51)
test bench_apache_log_no_match_start_anchor  ... bench:       1,995.72 ns/iter (+/- 42.47)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out; finished in 4.69s

     Running benches/log.rs (target/release/deps/log-c28f491c1fb11aff)

running 4 tests
test bench_log_match                 ... bench:         491.83 ns/iter (+/- 68.70)
test bench_log_match_with_anchors    ... bench:         463.17 ns/iter (+/- 44.47)
test bench_log_no_match              ... bench:         760.29 ns/iter (+/- 35.32)
test bench_log_no_match_with_anchors ... bench:         502.67 ns/iter (+/- 44.28)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 3.19s

     Running benches/simple.rs (target/release/deps/simple-70842287ce6bfb68)

running 4 tests
test bench_simple_pattern_match                ... bench:         187.28 ns/iter (+/- 37.28)
test bench_simple_pattern_match_with_anchor    ... bench:         204.94 ns/iter (+/- 51.67)
test bench_simple_pattern_no_match             ... bench:         106.57 ns/iter (+/- 6.22)
test bench_simple_pattern_no_match_with_anchor ... bench:         101.38 ns/iter (+/- 8.25)
```